### PR TITLE
Remove resources/public when building, and bump version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject markdown-to-hiccup "0.6.2"
+(defproject markdown-to-hiccup "0.6.3"
   :description "Simple library for converting markdown into hiccup data structures for Clojure/Script"
   :url "https://github.com/mpcarolin/markdown-to-hiccup"
   :dependencies [[org.clojure/clojure "1.10.0"]
@@ -23,5 +23,5 @@
   :plugins [[lein-npm "0.6.2"]]
   :npm {:dependencies [[source-map-support "0.4.0"]]}
   :source-paths ["src" "target/classes"]
-  :clean-targets [:target-path "out" "release"]
+  :clean-targets ^{:protect false} [:target-path "out" "release" "resources/public"]
   :target-path "target")


### PR DESCRIPTION
Fixes https://github.com/mpcarolin/markdown-to-hiccup/issues/5

I'm not extremely well-versed in Leiningen, but as far as I understand, [`:clean-targets`](https://github.com/technomancy/leiningen/blob/2fb603b2bfc44255faf721995be1dc70d6ce388d/sample.project.clj#L320C13-L320C20) is used when installing, building jars etc.

I verified that creating `resources/public/foo.txt` and then running `lein install` created a jar in my local `.m2` repo that contained a `public/foo.txt ` file. Applying this patch results in a jar without the file.

Also bumps version to `0.6.3`.